### PR TITLE
Fix boot failure if mouse is moved too early.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,10 @@ DISP_WIDTH ?= 512
 DISP_HEIGHT ?= 342
 CFLAGS_CFG = -DDISP_WIDTH=$(DISP_WIDTH) -DDISP_HEIGHT=$(DISP_HEIGHT) -DENABLE_AUDIO=$(ENABLE_AUDIO)
 
-all:	main
+all:	main patcher
+
+patcher: src/rom.c
+	$(CC) $(CFLAGS) -DUMAC_STANDALONE_PATCHER -o $@ $<
 
 $(MUSASHI_SRC): $(MUSASHI)/m68kops.h
 
@@ -75,7 +78,7 @@ main:	$(OBJS)
 
 clean:
 	make -C $(MUSASHI) clean
-	rm -f $(MY_OBJS) main
+	rm -f $(MY_OBJS) main patcher
 
 ################################################################################
 # Mac driver sources (no need to generally rebuild

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@
 
 DEBUG ?= 0
 MEMSIZE ?= 128
+ENABLE_AUDIO ?= 1
 
 SOURCES = $(wildcard src/*.c)
 
@@ -54,7 +55,7 @@ endif
 # Basic support for changing screen res (with the MacPlusV3 ROM)
 DISP_WIDTH ?= 512
 DISP_HEIGHT ?= 342
-CFLAGS_CFG = -DDISP_WIDTH=$(DISP_WIDTH) -DDISP_HEIGHT=$(DISP_HEIGHT)
+CFLAGS_CFG = -DDISP_WIDTH=$(DISP_WIDTH) -DDISP_HEIGHT=$(DISP_HEIGHT) -DENABLE_AUDIO=$(ENABLE_AUDIO)
 
 all:	main
 

--- a/include/machw.h
+++ b/include/machw.h
@@ -81,6 +81,8 @@ extern int overlay;
  * But, that should never happen post-boot.
  */
 #define CLAMP_RAM_ADDR(x) ((x) >= RAM_SIZE ? (x) % RAM_SIZE : (x))
+/* Is the address (previously clamped with CLAMP_RAM_ADDR) the audio trap address? (last byte of audio data) */
+#define IS_RAM_AUDIO_TRAP(x) (x == umac_get_audio_offset() + 2 * 369)
 
 #define IS_VIA(x)       ((ADR24(x) & 0xe80000) == 0xe80000)
 #define IS_IWM(x)       ((ADR24(x) >= 0xdfe1ff) && (ADR24(x) < (0xdfe1ff + 0x2000)))

--- a/include/scc.h
+++ b/include/scc.h
@@ -35,6 +35,8 @@ void    scc_write(unsigned int address, uint8_t data);
 uint8_t scc_read(unsigned int address);
 /* Set a new state for the DCD pins: */
 void    scc_set_dcd(int a, int b);
+/* check if scc master interrupt is enabled */
+int scc_get_mie();
 
 #endif
 

--- a/include/umac.h
+++ b/include/umac.h
@@ -53,4 +53,9 @@ static inline unsigned int      umac_get_fb_offset(void)
         return RAM_SIZE - ((DISP_WIDTH * DISP_HEIGHT / 8) + 0x380);
 }
 
+#define umac_get_audio_offset() (RAM_SIZE - 768)
+#define umac_get_audio_offset_end() (RAM_SIZE - 768 + 2 * 370)
+
+extern int umac_volume;
+
 #endif

--- a/include/umac.h
+++ b/include/umac.h
@@ -53,9 +53,12 @@ static inline unsigned int      umac_get_fb_offset(void)
         return RAM_SIZE - ((DISP_WIDTH * DISP_HEIGHT / 8) + 0x380);
 }
 
+#if ENABLE_AUDIO
 #define umac_get_audio_offset() (RAM_SIZE - 768)
 #define umac_get_audio_offset_end() (RAM_SIZE - 768 + 2 * 370)
 
-extern int umac_volume;
+void umac_audio_trap();
+void umac_audio_cfg(int volume, int sndres);
+#endif
 
 #endif

--- a/include/umac.h
+++ b/include/umac.h
@@ -34,6 +34,7 @@ int     umac_loop(void);
 void    umac_reset(void);
 void    umac_opt_disassemble(int enable);
 void    umac_mouse(int deltax, int deltay, int button);
+void    umac_absmouse(int x, int y, int button);
 void    umac_kbd_event(uint8_t scancode, int down);
 
 static inline void      umac_vsync_event(void)

--- a/include/umac.h
+++ b/include/umac.h
@@ -56,6 +56,9 @@ static inline unsigned int      umac_get_fb_offset(void)
 #if ENABLE_AUDIO
 #define umac_get_audio_offset() (RAM_SIZE - 768)
 #define umac_get_audio_offset_end() (RAM_SIZE - 768 + 2 * 370)
+extern unsigned first_audio_sample;
+#define umac_get_first_audio_sample() (first_audio_sample)
+#define umac_reset_first_audio_sample() (first_audio_sample = 0, (void)0)
 
 void umac_audio_trap();
 void umac_audio_cfg(int volume, int sndres);

--- a/include/via.h
+++ b/include/via.h
@@ -40,7 +40,8 @@ struct via_cb {
 void    via_init(struct via_cb *cb);
 void    via_write(unsigned int address, uint8_t data);
 uint8_t via_read(unsigned int address);
-void    via_tick(uint64_t time);
+void    via_tick(int cycles);
+int     via_limit_cycles(int cycles);
 /* Trigger an event on CA1 or CA2: */
 void    via_caX_event(int ca);
 void    via_sr_rx(uint8_t val);

--- a/src/main.c
+++ b/src/main.c
@@ -668,8 +668,7 @@ int     umac_loop(void)
         int cycles = UMAC_EXECLOOP_QUANTUM * 8;
         cycles = via_limit_cycles(cycles);
         int used_cycles = m68k_execute(cycles);
-printf("Asked to execute %d cycles, actual %d cycles\n",
-cycles, used_cycles);
+        MDBG("Asked to execute %d cycles, actual %d cycles\n", cycles, used_cycles);
         global_cycles += used_cycles;
         global_time_us = global_cycles / 8;
 

--- a/src/main.c
+++ b/src/main.c
@@ -618,13 +618,39 @@ void    umac_opt_disassemble(int enable)
  *
  * X is positive going right; Y is positive going upwards.
  */
-void    umac_mouse(int deltax, int deltay, int button)
+void    umac_absmouse(int x, int y, int button)
 {
+    if (!scc_get_mie()) return;
 #define MTemp_h 0x82a
 #define MTemp_v 0x828
 #define CrsrNew 0x8ce
 #define CrsrCouple 0x8cf
 
+        int oldx = RAM_RD16(MTemp_h);
+        int oldy = RAM_RD16(MTemp_v);
+
+        if(x != oldx) {
+            RAM_WR16(MTemp_h, x);
+        }
+
+        if (y != oldy) {
+            RAM_WR16(MTemp_v, y);
+        }
+
+        if(x != oldx || y != oldy) {
+            RAM_WR8(CrsrNew, RAM_RD8(CrsrCouple));
+        }
+
+        via_mouse_pressed = button;
+}
+
+/* Provide mouse input (movement, button) data.
+ *
+ * X is positive going right; Y is positive going upwards.
+ */
+void    umac_mouse(int deltax, int deltay, int button)
+{
+    if (!scc_get_mie()) return;
         if(deltax) {
             int16_t temp_h = RAM_RD16(MTemp_h) + deltax;
             RAM_WR16(MTemp_h, temp_h);

--- a/src/main.c
+++ b/src/main.c
@@ -40,6 +40,7 @@
 #include <errno.h>
 #include <setjmp.h>
 
+#include "umac.h"
 #include "machw.h"
 #include "m68k.h"
 #include "via.h"
@@ -70,6 +71,7 @@ static unsigned int g_int_controller_highest_int = 0;  /* Highest pending interr
 uint8_t *_ram_base;
 uint8_t *_rom_base;
 
+int umac_volume = 0;
 int overlay = 1;
 static uint64_t global_time_us = 0;
 static int sim_done = 0;
@@ -154,6 +156,7 @@ static void     via_ra_changed(uint8_t val)
                 MDBG("OVERLAY CHANGING\n");
                 update_overlay_layout();
         }
+        umac_volume = val & 7;
 
         oldval = val;
 }

--- a/src/rom.c
+++ b/src/rom.c
@@ -116,6 +116,9 @@ static void     rom_patch_plusv3(uint8_t *rom_base)
          * allowing the ROM checksum to fail (it returns failure, then
          * we carry on).  This avoids wild RAM addrs being accessed.
          */
+
+        /* Fix up the sound buffer as used by BootBeep */
+        ROM_WR32(0x292, RAM_SIZE - 768);
 #endif
 
 #if DISP_WIDTH != 512 || DISP_HEIGHT != 342

--- a/src/scc.c
+++ b/src/scc.c
@@ -126,6 +126,8 @@ static void     scc_wr3(int AnB, uint8_t data)
         }
 }
 
+int scc_get_mie() { return scc_mie; }
+
 // WR9: Master Interrupt control and reset commands
 static void     scc_wr9(uint8_t data)
 {

--- a/src/unix_main.c
+++ b/src/unix_main.c
@@ -287,8 +287,14 @@ int     main(int argc, char *argv[])
                 perror("SDL window");
                 return 1;
         }
-        SDL_SetWindowGrab(window, SDL_TRUE);
-        SDL_SetRelativeMouseMode(SDL_TRUE);
+
+        static const int absmouse = 1;
+        if (!absmouse) {
+            SDL_SetWindowGrab(window, SDL_TRUE);
+            SDL_SetRelativeMouseMode(SDL_TRUE);
+        } else {
+            SDL_ShowCursor(SDL_DISABLE);
+        }
 
         SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "linear");
 
@@ -355,7 +361,8 @@ int     main(int argc, char *argv[])
                 SDL_Event event;
                 int mousex = 0;
                 int mousey = 0;
-
+                int send_mouse = 0;
+                static int absmousex, absmousey;
                 if (SDL_PollEvent(&event)) {
                         switch (event.type) {
                         case SDL_QUIT:
@@ -372,21 +379,32 @@ int     main(int argc, char *argv[])
                         } break;
 
                         case SDL_MOUSEMOTION:
+                                send_mouse = 1;
+                                absmousex = event.motion.x / DISP_SCALE;
+                                absmousey = event.motion.y / DISP_SCALE;
                                 mousex = event.motion.xrel;
                                 mousey = -event.motion.yrel;
                                 break;
 
                         case SDL_MOUSEBUTTONDOWN:
+                                send_mouse = 1;
                                 mouse_button = 1;
                                 break;
 
                         case SDL_MOUSEBUTTONUP:
+                                send_mouse = 1;
                                 mouse_button = 0;
                                 break;
                         }
                 }
 
-                umac_mouse(mousex, mousey, mouse_button);
+                if (send_mouse) {
+                    if(absmouse) {
+                        umac_absmouse(absmousex, absmousey, mouse_button);
+                    } else {
+                        umac_mouse(mousex, mousey, mouse_button);
+                    }
+                }
 
                 done |= umac_loop();
 

--- a/src/unix_main.c
+++ b/src/unix_main.c
@@ -403,6 +403,18 @@ int     main(int argc, char *argv[])
                         umac_vsync_event();
 
                         copy_fb(framebuffer, ram_get_base() + umac_get_fb_offset());
+
+        uint16_t *audioptr = (uint16_t*)((uint8_t*)ram_base + umac_get_audio_offset());
+        for(int i=0; i<DISP_HEIGHT; i++) {
+            int d = *audioptr++ & 0xff;
+            for(int j=0; j<8; j++) {
+                if (d & (1 << j)) {
+                    uint32_t fbdata = framebuffer[j + i * DISP_WIDTH];
+                    fbdata = (fbdata & ~0xff) | ((d & (1 << j)) ? 0xff : 0);
+                    framebuffer[j + i * DISP_WIDTH] = fbdata;
+                }
+            }
+        }
                         SDL_UpdateTexture(texture, NULL, framebuffer,
                                           DISP_WIDTH * sizeof (Uint32));
                         /* Scales texture up to window size */

--- a/src/via.c
+++ b/src/via.c
@@ -339,7 +339,7 @@ void    via_tick(int cycles)
             if (i <= 0) {
                 i = 0;
                 VDBG("[VIA T2 reached zero, IRQ pending]\n");
-                irq_active |= VIA_IRQ_T2;
+                // irq_active |= VIA_IRQ_T2;
                 via_assess_irq();
             }
             via_t2c = i;

--- a/src/via.c
+++ b/src/via.c
@@ -243,7 +243,6 @@ void    via_write(unsigned int address, uint8_t data)
                 }
                 // writing T2CH clears associated IRQ flag
                 irq_active &= ~VIA_IRQ_T2;
-                via_assess_irq();
                 break;
         case VIA_T2CL:
                 VDBG("VIA T2CL %02x [ACR=%02x]\n", data, via_regs[VIA_ACR]);
@@ -313,7 +312,6 @@ uint8_t via_read(unsigned int address)
                 data = via_t2c & 0xff;
                 // reading T2LL clears associated IRQ flag
                 irq_active &= ~VIA_IRQ_T2;
-                via_assess_irq();
                 break;
         default:
                 VDBG("[VIA: unhandled RD of %s (reg 0x%x)]\n", rname, r);


### PR DESCRIPTION
& merge accumulated changes into Adafruit's main branch.

Note that currently adafruit's pico-mac is using 431e905354e975cd942eb4c1c5ea5a39237691ab so the only change that this will introduce is https://github.com/adafruit/umac/commit/f868c8669fbc3c55caa80c2afed41de85f596a8c

Basically, the change I had made to "turbocharge mouse movement" could happen too early. This can lead to a "sad mac" if the mouse is being moved while the system boots. Basically, I suspect that the changing low memory locations cause a RAM test failure.

Once this is merged I'll make a companion PR in pico-mac to bring it up to date with umac.